### PR TITLE
Add PID and port parsing to OSX

### DIFF
--- a/lib/netstat.js
+++ b/lib/netstat.js
@@ -14,7 +14,7 @@ var commands = {
     },
     darwin: {
         cmd: 'netstat',
-        args: ['-p', 'tcp']
+        args: ['-v', '-n', '-p', 'tcp']
     },
     win32: {
         cmd: 'netstat',
@@ -44,7 +44,7 @@ module.exports = function (options, callback) {
     }
 
     if (options.limit && options.limit > 0) {
-        handler = filters.limit(handler, options.limit);
+        handler = filters.limit(handler, options.limit, noop);
     }
 
     if (options.filter) {
@@ -54,7 +54,7 @@ module.exports = function (options, callback) {
     activator(command.cmd, command.args, makeLineHandler, done);
 };
 
-exports.commands = commands;
-exports.filters = filters;
-exports.parsers = parsers;
-exports.version = pkg.version;
+module.exports.commands = commands;
+module.exports.filters = filters;
+module.exports.parsers = parsers;
+module.exports.version = pkg.version;

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -21,7 +21,7 @@ exports.linux = function (line, callback) {
 
 exports.darwin = function (line, callback) {
     var parts = line.split(/\s/).filter(String);
-    if (!parts.length || parts.length != 6) {
+    if (!parts.length || parts.length != 10) {
         return;
     }
 
@@ -30,7 +30,7 @@ exports.darwin = function (line, callback) {
         local: parts[3],
         remote: parts[4],
         state: parts[5],
-        pid: '-'
+        pid: parts[8]
     };
 
     return callback(normalizeValues(item));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,10 +21,13 @@ var parseAddress = exports.parseAddress = function (raw) {
     } else if (raw.indexOf(':') != raw.lastIndexOf(':')) {
         port = raw.substring(raw.lastIndexOf(':') + 1);
         address = raw.substring(0, raw.lastIndexOf(':'));
-    } else {
+    } else if (raw.indexOf(':') == raw.lastIndexOf(':') && raw.indexOf(':') != -1) {
         var parts = raw.split(':');
         port = parts[1];
         address = parts[0] || null;
+    } else if (raw.indexOf('.') != raw.lastIndexOf('.')) {
+        port = raw.substring(raw.lastIndexOf('.') + 1);
+        address = raw.substring(0, raw.lastIndexOf('.'));
     }
 
     if (address && (address == '::' || address == '0.0.0.0')) {

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -35,7 +35,7 @@ describe('Parsers', function () {
 
     describe('darwin', function () {
         beforeEach(function () {
-            line = 'tcp4        0      0 2.2.5.144:35507    1.2.3.4:80      ESTABLISHED';
+            line = 'tcp4       0      0  10.59.107.171.55383    17.146.1.14.443        ESTABLISHED 262144 131400    312      0';
         });
 
         it('should parse the correct fields', function () {
@@ -43,16 +43,16 @@ describe('Parsers', function () {
                 expect(data).to.deep.equal({
                     protocol: 'tcp',
                     local: {
-                        address: '2.2.5.144',
-                        port: 35507
+                        address: '10.59.107.171',
+                        port: 55383
                     },
                     remote: {
-                        address: '1.2.3.4',
-                        port: 80
+                        address: '17.146.1.14',
+                        port: 443
                     },
 
                     state: 'ESTABLISHED',
-                    pid: 0
+                    pid: 312
                 });
             });
         });

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,6 +11,13 @@ describe('Utils', function () {
             });//[::]:0
         });
 
+        it('should parse darwin-format ip4 addresses with port', function () {
+            expect(utils.parseAddress('10.59.107.189.54728')).to.deep.equal({
+                address: '10.59.107.189',
+                port: 54728
+            });//[::]:0
+        });
+
         it('should parse ip6 addresses with port', function () {
             expect(utils.parseAddress('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:1900')).to.deep.equal({
                 address: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',


### PR DESCRIPTION
This commit changes 2 things for OSX ('darwin'):
1. Make `netstat` output the PID with the `-v` argument (and parse the
PID in lib/parsers)
2. Make lib/utils.parseAddress handle OSX addresses (which have the
strange format `ip.addr.port`, e.g. `127.0.0.1.22`)

Additionally, this commit fixes a bug when setting the "limit" option:
The filters.limit function was not being passed a "stop()" function,
which caused it to throw an error when trying to call stop() after
the limit was reached.

Also, because `module.exports` was reassigned in lib/netstat.js:25, the
`exports` at the bottom were not being exported. The fix is to assign
them to `module.exports`.
