### PR TITLE
Export `utils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ function (line, callback) {
 
 A hash map of closure factories to handle logic for certain options. See [source](https://github.com/danielkrainas/node-netstat/blob/master/lib/filters.js) for more details on implementations for specific filters.
 
+### `object netstat.utils`
+
+An object with several useful functions for implementing custom parsers.
 
 ### `string netstat.version`
 

--- a/lib/netstat.js
+++ b/lib/netstat.js
@@ -2,7 +2,7 @@
 
 var os = require('os');
 var activators = require('./activators');
-var noop = require('./utils').noop;
+var utils = require('./utils');
 var parsers = require('./parsers');
 var filters = require('./filters');
 var pkg = require('../package');
@@ -24,7 +24,7 @@ var commands = {
 
 module.exports = function (options, callback) {
     options = options || {};
-    var done = options.done || noop;
+    var done = options.done || utils.noop;
     var platform = options.platform || os.platform();
     var command = commands[platform];
     var parser = parsers[platform];
@@ -44,7 +44,7 @@ module.exports = function (options, callback) {
     }
 
     if (options.limit && options.limit > 0) {
-        handler = filters.limit(handler, options.limit, noop);
+        handler = filters.limit(handler, options.limit, utils.noop);
     }
 
     if (options.filter) {
@@ -57,4 +57,5 @@ module.exports = function (options, callback) {
 module.exports.commands = commands;
 module.exports.filters = filters;
 module.exports.parsers = parsers;
+module.exports.utils = utils;
 module.exports.version = pkg.version;


### PR DESCRIPTION
Exporting `utils` makes it easier to overide the default parsers. For
example, my `netstat` implementation does not expose PIDs, so I have
overidden the linux parser like this:

```
netstat.parsers.linux = function (line, callback) {
    var parts = line.split(/\s/).filter(String);
    if (!parts.length || parts.length != 6) {
        return;
    }

    var item = {
        protocol: parts[0],
        local: parts[3],
        remote: parts[4],
        state: parts[5],
        pid: '-'
    };

    return callback(netstat.utils.normalizeValues(item));
}
```

Having `utils` exposed allows me to use the `normalizeValues` function.
