### PR TITLE
Expose the activators in exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ A hash map of closure factories to handle logic for certain options. See [source
 
 An object with several useful functions for implementing custom parsers.
 
+### `object netstat.activators`
+
+An object containing the functions for spawning the shell command. These functions are exposed so that they can be replaced if needed, but most users will not need to modify them.
+
 ### `string netstat.version`
 
 The version of node-netstat

--- a/lib/netstat.js
+++ b/lib/netstat.js
@@ -54,6 +54,7 @@ module.exports = function (options, callback) {
     activator(command.cmd, command.args, makeLineHandler, done);
 };
 
+module.exports.activators = activators;
 module.exports.commands = commands;
 module.exports.filters = filters;
 module.exports.parsers = parsers;


### PR DESCRIPTION
The default activator is not working for me (see issue #4 -- `done()` is
called before all the output is parsed), so I need to override it. I
also can't use the default `sync` activator, because on Node v0.10.43,
which I must use, there is no child_process.spawnSync. Anyway, those
are personal problems ;) but it may be useful for some others to also
have access to the activators object?
