### PR TITLE
Fixed returning UDP data on Windows

### DIFF
--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -40,17 +40,21 @@ exports.darwin = function (line, callback) {
 
 exports.win32 = function (line, callback) {
     var parts = line.split(/\s/).filter(String);
-    if (!parts.length || parts.length != 5) {
-        return;
-    }
-
-    var item = {
-        protocol: parts[0],
-        local: parts[1],
-        remote: parts[2],
-        state: parts[3],
-        pid: parts[4]
+    if (!parts.length) {
+      return
     };
+
+    var item = { };
+
+    if (parts.length == 4 || parts.length == 5) {
+      item.protocol = parts.shift();
+      item.local = parts.shift();
+      item.remote = parts.shift();
+      item.pid = parts.pop();
+      item.state = parts[0] || null;
+    } else {
+      return;
+    }
 
     return callback(normalizeValues(item));
 };


### PR DESCRIPTION
In Windows when running 'netstat -ano' TCP connections return a state but UDP do not. As a result, when lib/parsers.js win32 function did a check for "parts.length != 5" it was completely skipping over the UDP connections.