### PR TITLE
Add support for Windows Subsystem for Linux (WSL)

### DIFF
--- a/lib/activators.js
+++ b/lib/activators.js
@@ -14,7 +14,8 @@ exports.sync = function (cmd, args, makeLineHandler, done) {
         processing = false;
     });
 
-    var proc = exports._spawnSync(cmd, args);
+    // var proc = exports._spawnSync(cmd, args);
+    var proc = exports._spawnSync('powershell.exe', [cmd, '-ano']);
     if (proc.error) {
         return done(proc.error);
     }
@@ -29,7 +30,8 @@ exports.sync = function (cmd, args, makeLineHandler, done) {
 
 exports.async = function (cmd, args, makeLineHandler, done) {
     var killed = false;
-    var proc = exports._spawn(cmd, args);
+    // var proc = exports._spawn(cmd, args);
+    var proc = exports._spawn('powershell.exe', [cmd, '-ano']);
 
     var lineHandler = makeLineHandler(function () {
         if (!killed) {
@@ -44,7 +46,6 @@ exports.async = function (cmd, args, makeLineHandler, done) {
             return done(err);
         }
     };
-
     emitLines(proc.stdout);
     proc.on('error', done);
     proc.on('close', function () {

--- a/lib/activators.js
+++ b/lib/activators.js
@@ -44,6 +44,7 @@ exports.async = function (cmd, args, makeLineHandler, done) {
             return done(err);
         }
     };
+
     emitLines(proc.stdout);
     proc.on('error', done);
     proc.on('close', function () {

--- a/lib/activators.js
+++ b/lib/activators.js
@@ -14,8 +14,7 @@ exports.sync = function (cmd, args, makeLineHandler, done) {
         processing = false;
     });
 
-    // var proc = exports._spawnSync(cmd, args);
-    var proc = exports._spawnSync('powershell.exe', [cmd, '-ano']);
+    var proc = exports._spawnSync(cmd, args);
     if (proc.error) {
         return done(proc.error);
     }
@@ -30,8 +29,7 @@ exports.sync = function (cmd, args, makeLineHandler, done) {
 
 exports.async = function (cmd, args, makeLineHandler, done) {
     var killed = false;
-    // var proc = exports._spawn(cmd, args);
-    var proc = exports._spawn('powershell.exe', [cmd, '-ano']);
+    var proc = exports._spawn(cmd, args);
 
     var lineHandler = makeLineHandler(function () {
         if (!killed) {

--- a/lib/netstat.js
+++ b/lib/netstat.js
@@ -27,7 +27,6 @@ module.exports = function (options, callback) {
     options = options || {};
     var done = options.done || utils.noop;
     var platform = options.platform || (isWsl ? 'win32' : false) || os.platform();
-	// TODO: Fix this
     var command = commands[platform];
     var parser = parsers[platform];
     var handler = callback;

--- a/lib/netstat.js
+++ b/lib/netstat.js
@@ -26,8 +26,11 @@ module.exports = function (options, callback) {
     options = options || {};
     var done = options.done || utils.noop;
     var platform = options.platform || os.platform();
-    var command = commands[platform];
-    var parser = parsers[platform];
+	// TODO: Fix this
+    // var command = commands[platform];
+	var command = commands['win32'];
+    // var parser = parsers[platform];
+    var parser = parsers['win32'];
     var handler = callback;
     var activator = options.sync ? activators.sync : activators.async;
 

--- a/lib/netstat.js
+++ b/lib/netstat.js
@@ -6,6 +6,7 @@ var utils = require('./utils');
 var parsers = require('./parsers');
 var filters = require('./filters');
 var pkg = require('../package');
+const isWsl = require('is-wsl');
 
 var commands = {
     linux: {
@@ -17,7 +18,7 @@ var commands = {
         args: ['-v', '-n', '-p', 'tcp']
     },
     win32: {
-        cmd: 'netstat',
+        cmd: 'netstat.exe',
         args: ['-a', '-n', '-o']
     }
 };
@@ -25,12 +26,10 @@ var commands = {
 module.exports = function (options, callback) {
     options = options || {};
     var done = options.done || utils.noop;
-    var platform = options.platform || os.platform();
+    var platform = options.platform || (isWsl ? 'win32' : false) || os.platform();
 	// TODO: Fix this
-    // var command = commands[platform];
-	var command = commands['win32'];
-    // var parser = parsers[platform];
-    var parser = parsers['win32'];
+    var command = commands[platform];
+    var parser = parsers[platform];
     var handler = callback;
     var activator = options.sync ? activators.sync : activators.async;
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "scripts": {
     "test": "node node_modules/grunt-cli/bin/grunt test"
   },
+  "dependencies": {
+    "is-wsl": "^1.1.0"
+  },
   "keywords": [
     "netstat",
     "utility"


### PR DESCRIPTION
WSL does not support `netstat` or `lsof` yet. Therefore, the PID can be retrieved from `ps` command but the port is not found for the PID.

Microsoft has said they are working on the issue and hopefully a future release will support `netstat` and `lsof`. https://github.com/Microsoft/WSL/issues/2249

However, a solution that works is to use netstat for Windows in WSL which can be called by simply running the command netstat.exe. (If you just do netstat, then it uses the Linux netstat which does not return processes).

The rest of this PR is including an is-wsl library to check if using WSL because otherwise the os.platform will return Linux. If using WSL, default to win32 platform.

**Note:** I was debating whether or not to include is-wsl and check for that or just rely on the developer to manually set the `platform` option to win32 if using WSL. If you prefer the latter option, let me know and I can make this PR just switch netstat to netstat.exe command.

This is necessary for me to add support for is-mongodb-running module to work correctly in WSL. See here: https://github.com/mongodb-js/is-mongodb-running/issues/8