### PR TITLE
fix for normalizing linux pids with abs paths

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,7 +54,7 @@ exports.normalizeValues = function (item) {
         item.pid = 0;
     } else if (~item.pid.indexOf('/')) {
         parts = item.pid.split('/');
-        item.pid = parts.length == 2 ? parts[0] : 0;
+        item.pid = parts.length > 1 ? parts[0] : 0;
     } else if (isNaN(item.pid)) {
         item.pid = 0;
     }


### PR DESCRIPTION
If a process is run by absolute path it may have multiple '/'s in it.

This patch adjusts normalizeValues() to not return 0 for pid in such cases.
I haven't reviewed process name parsing to see if a change is warranted there too.