### PR TITLE
Update parser-factories.js

### DIFF
--- a/lib/parser-factories.js
+++ b/lib/parser-factories.js
@@ -73,7 +73,7 @@ exports.win32 = function (options) {
             protocol: parts[0],
             local: parts[1],
             remote: parts[2],
-            state: parts[3] || null,
+            state: Number(parts[3]) ? null : parts[3],
             pid: parts[parts.length - 1]
         };
 


### PR DESCRIPTION
This fixes an issue where sometimes netstat on windows won't return a state. This checks to see if it's looking at the pid instead of the state by checking if it's a number.