### PR TITLE
Fix parser for MacOS Sonoma, support UDP on MacOS.

### DIFF
--- a/lib/netstat.js
+++ b/lib/netstat.js
@@ -16,7 +16,7 @@ var commands = {
     },
     darwin: {
         cmd: 'netstat',
-        args: ['-v', '-n', '-p', 'tcp']
+        args: ['-v', '-n']
     },
     win32: {
         cmd: 'netstat.exe',

--- a/lib/parser-factories.js
+++ b/lib/parser-factories.js
@@ -44,16 +44,18 @@ exports.darwin = function (options) {
 
   return function (line, callback) {
       var parts = line.split(/\s/).filter(String);
-      if (!parts.length || (parts.length != 10 && parts.length != 12)) {
+      if (parts.length === 0 || (parts[0].indexOf('tcp') < 0 && parts[0].indexOf('udp') < 0)) {
           return;
       }
 
+      const protocol = parts[0];
+
       var item = {
-          protocol: parts[0] == 'tcp4' ? 'tcp' : parts[0],
+          protocol: protocol === 'tcp4' ? 'tcp' : protocol === 'udp4' ? 'udp' : protocol,
           local: parts[3],
           remote: parts[4],
           state: parts[5],
-          pid: parts[8]
+          pid: parts[protocol.indexOf('udp') === 0 ? 7 : 8]
       };
 
       return callback(normalizeValues(item));


### PR DESCRIPTION
This PR fixes `node-netstat` for MacOS Sonoma (and possible other versions of MacOS) and also adds support for UDP and UDP6 on Mac.